### PR TITLE
manually create adapter

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,28 +1,31 @@
 ---
+
 ---
 
 <head>
-	<title>Chart with Day.js and Chart.js</title>
-  
-	<!-- Load Chart.js from cdnjs CDN (v4.0.1) -->
-	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.0.1/chart.umd.min.js"></script>
-  
-	<!-- Load Day.js from cdnjs CDN (latest version) -->
-	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.7/dayjs.min.js"></script>
-  
-	<!-- Load Chart.js Day.js Adapter from cdnjs CDN (v3.0.0) -->
-	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-adapter-dayjs/3.0.0/chartjs-adapter-dayjs.umd.min.js"></script>
-  
-	<!-- Link the JavaScript file that plots the chart -->
-	<script defer type="module" src="/src/plotChart.js"></script>
-  </head>
-  
-  <body>
-	<h1>Chart Example</h1>
-  
-	<!-- Canvas for the Chart -->
-	<div class="chart-container">
-	  <canvas id="myChart" width="400" height="200"></canvas>
-	</div>
-  </body>
-  
+  <title>Chart with Day.js and Chart.js</title>
+
+  <!-- Load Chart.js from cdnjs CDN (v4.0.1) -->
+  <script
+    defer
+    src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.0.1/chart.umd.min.js"
+  ></script>
+
+  <!-- Load Day.js from cdnjs CDN (latest version) -->
+  <script
+    defer
+    src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.7/dayjs.min.js"
+  ></script>
+
+  <!-- Link the JavaScript file that plots the chart -->
+  <script defer type="module" src="/src/plotChart.js"></script>
+</head>
+
+<body>
+  <h1>Chart Example</h1>
+
+  <!-- Canvas for the Chart -->
+  <div class="chart-container">
+    <canvas id="myChart" width="400" height="200"></canvas>
+  </div>
+</body>

--- a/src/plotChart.js
+++ b/src/plotChart.js
@@ -1,61 +1,91 @@
-document.addEventListener('DOMContentLoaded', () => {
-  if (typeof Chart !== 'undefined') {
-    console.log('Chart.js is loaded. Plotting chart...');
-    
-    // Check if date adapter is loaded
-    if (typeof Chart._adapters._date !== 'undefined') {
-      console.log('Date adapter is loaded:', Chart._adapters._date);
-    } else {
-      console.error('Date adapter is not loaded!');
-      return;
-    }
-    
-    const ctx = document.getElementById('myChart').getContext('2d');
-    const labels = [
-      new Date(Date.now() - 4 * 24 * 60 * 60 * 1000),
-      new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
-      new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-      new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
-      new Date()
-    ];
+document.addEventListener("DOMContentLoaded", () => {
+  // Manually register the dayjs adapter for Chart.js
+  if (typeof Chart !== "undefined" && typeof dayjs !== "undefined") {
+    // Register the date adapter explicitly
+    Chart._adapters._date.override({
+      _id: "dayjs",
+      formats() {
+        return {
+          datetime: "MMM D, YYYY, h:mm:ss a",
+          millisecond: "h:mm:ss.SSS a",
+          second: "h:mm:ss a",
+          minute: "h:mm a",
+          hour: "hA",
+          day: "MMM D",
+          week: "ll",
+          month: "MMM YYYY",
+          quarter: "[Q]Q - YYYY",
+          year: "YYYY",
+        };
+      },
+      parse(value, format) {
+        return dayjs(value, format).isValid()
+          ? dayjs(value, format).valueOf()
+          : null;
+      },
+      format(time, format) {
+        return dayjs(time).format(format);
+      },
+      add(time, amount, unit) {
+        return dayjs(time).add(amount, unit).valueOf();
+      },
+      diff(max, min, unit) {
+        return dayjs(max).diff(dayjs(min), unit);
+      },
+      startOf(time, unit, weekday) {
+        return dayjs(time).startOf(unit).valueOf();
+      },
+      endOf(time, unit) {
+        return dayjs(time).endOf(unit).valueOf();
+      },
+    });
+  }
 
-    new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels: labels,
-        datasets: [{
-          label: 'Sample Data',
+  const ctx = document.getElementById("myChart").getContext("2d");
+  const labels = [
+    new Date(Date.now() - 4 * 24 * 60 * 60 * 1000),
+    new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+    new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+    new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+    new Date(),
+  ];
+
+  new Chart(ctx, {
+    type: "line",
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: "Sample Data",
           data: [10, 15, 12, 20, 25],
           fill: false,
-          borderColor: 'rgb(75, 192, 192)',
-          tension: 0.1
-        }]
-      },
-      options: {
-        responsive: true,
-        scales: {
-          x: {
-            type: 'time',
-            time: {
-              unit: 'day',
-              tooltipFormat: 'MMM d'
-            },
-            title: {
-              display: true,
-              text: 'Date'
-            }
+          borderColor: "rgb(75, 192, 192)",
+          tension: 0.1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      scales: {
+        x: {
+          type: "time",
+          time: {
+            unit: "day",
+            tooltipFormat: "MMM d",
           },
-          y: {
-            beginAtZero: true,
-            title: {
-              display: true,
-              text: 'Value'
-            }
-          }
-        }
-      }
-    });
-  } else {
-    console.error('Chart.js is not loaded!');
-  }
+          title: {
+            display: true,
+            text: "Date",
+          },
+        },
+        y: {
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: "Value",
+          },
+        },
+      },
+    },
+  });
 });


### PR DESCRIPTION
I reckon there's some incompatibility between the versions of the adapter and the chartjs library, so by registering the adapter manually the adapter is no longer needed and can be removed.